### PR TITLE
IPD-28652: changes to add support for workflow versions to sdk

### DIFF
--- a/infoworks/sdk/url_builder.py
+++ b/infoworks/sdk/url_builder.py
@@ -573,7 +573,25 @@ def create_workflow_url(config, domain_id):
     return request
 
 
-def configure_workflow_url(config, domain_id, workflow_id):
+def create_workflow_version_url(config, domain_id, workflow_id):
+    """
+    returns URL to create workflow using v3 api
+    :param config: client configurations
+    :type config: dict
+    :param workflow_id: Identifier for workflow
+    :type workflow_id: string
+    :param domain_id: Identifier for domain
+    :type domain_id: string
+    :return: url for the workflow creation
+    """
+    request = '{protocol}://{ip}:{port}/v3/domains/{domain_id}/workflows/{workflow_id}/versions'.format(ip=config['ip'], port=config['port'],
+                                                                                 protocol=config['protocol'],
+                                                                                 domain_id=domain_id,
+                                                                                 workflow_id=workflow_id)
+    return request
+
+
+def configure_workflow_url(config, domain_id, workflow_id, workflow_version_id=None):
     """
     returns URL to configure workflow using v3 api
     :param config: client configurations
@@ -582,17 +600,27 @@ def configure_workflow_url(config, domain_id, workflow_id):
     :type domain_id: string
     :param workflow_id: Identifier for workflow
     :type workflow_id: string
+    :param workflow_version_id: Identifier for workflow version
+    :type workflow_version_id: string
     :return: url to configure workflow
     """
-    request = '{protocol}://{ip}:{port}/v3/domains/{domain_id}/workflows/{workflow_id}/config-migration'.format(
-        ip=config['ip'], port=config['port'],
-        protocol=config['protocol'],
-        domain_id=domain_id,
-        workflow_id=workflow_id)
+    if workflow_version_id:
+        request = '{protocol}://{ip}:{port}/v3/domains/{domain_id}/workflows/{workflow_id}/config-migration?version_id={workflow_version_id}'.format(
+            ip=config['ip'], port=config['port'],
+            protocol=config['protocol'],
+            domain_id=domain_id,
+            workflow_id=workflow_id,
+            workflow_version_id=workflow_version_id)
+    else:
+        request = '{protocol}://{ip}:{port}/v3/domains/{domain_id}/workflows/{workflow_id}/config-migration'.format(
+            ip=config['ip'], port=config['port'],
+            protocol=config['protocol'],
+            domain_id=domain_id,
+            workflow_id=workflow_id)
     return request
 
 
-def trigger_workflow_url(config, domain_id, workflow_id):
+def trigger_workflow_url(config, domain_id, workflow_id, workflow_version_id=None):
     """
     returns URL to trigger a workflow using v3 api
     :param config: client configurations
@@ -601,13 +629,23 @@ def trigger_workflow_url(config, domain_id, workflow_id):
     :type domain_id: string
     :param workflow_id: Identifier for workflow
     :type workflow_id: string
+    :param workflow_version_id: Identifier for workflow
+    :type workflow_version_id: string
     :return: url to trigger workflow
     """
-    request = '{protocol}://{ip}:{port}/v3/domains/{domain_id}/workflows/{workflow_id}/start'.format(
-        ip=config['ip'], port=config['port'],
-        protocol=config['protocol'],
-        domain_id=domain_id,
-        workflow_id=workflow_id)
+    if workflow_version_id:
+        request = '{protocol}://{ip}:{port}/v3/domains/{domain_id}/workflows/{workflow_id}/start?workflow_version_id={workflow_version_id}'.format(
+            ip=config['ip'], port=config['port'],
+            protocol=config['protocol'],
+            domain_id=domain_id,
+            workflow_id=workflow_id,
+            workflow_version_id=workflow_version_id)
+    else:
+        request = '{protocol}://{ip}:{port}/v3/domains/{domain_id}/workflows/{workflow_id}/start'.format(
+            ip=config['ip'], port=config['port'],
+            protocol=config['protocol'],
+            domain_id=domain_id,
+            workflow_id=workflow_id)
     return request
 
 
@@ -647,6 +685,19 @@ def get_all_workflows_url(config):
     :return: url fetch all workflows in Infoworks using v3 api
     """
     request = '{protocol}://{ip}:{port}/v3/admin/workflows'.format(
+        ip=config['ip'], port=config['port'],
+        protocol=config['protocol'])
+    return request
+
+
+def get_all_workflow_versions_url(config):
+    """
+    returns URL to fetch all workflows in Infoworks using v3 api
+    :param config: client configurations
+    :type config: dict
+    :return: url fetch all workflows in Infoworks using v3 api
+    """
+    request = '{protocol}://{ip}:{port}/v3/admin/workflow-versions'.format(
         ip=config['ip'], port=config['port'],
         protocol=config['protocol'])
     return request

--- a/infoworks/sdk/workflow_response.py
+++ b/infoworks/sdk/workflow_response.py
@@ -3,7 +3,7 @@ class WorkflowResponse:
         pass
 
     @staticmethod
-    def parse_result(status=None, error_code=None, error_desc=None, job_id=None, workflow_id=None, response=None):
+    def parse_result(status=None, error_code=None, error_desc=None, job_id=None, workflow_id=None, workflow_version_id=None, response=None):
         result = {
             'error': {
                 'error_code': error_code,
@@ -13,6 +13,7 @@ class WorkflowResponse:
                 'job_id': job_id,
                 'status': status,
                 'workflow_id': str(workflow_id) if workflow_id is not None else "",
+                'workflow_version_id': str(workflow_version_id) if workflow_version_id is not None else "",
                 'response': response
             }
         }

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="infoworkssdk",
-    version="5.0.9",
+    version="5.1.0",
     author="Infoworks CE Team",
     author_email="customer-engineering@infoworks.io",
-    description="A package to work with Infoworks via SDK. This library is compatible with Infoworks v6.x onwards. Code can be found in https://github.com/Infoworks/InfoworksPythonSDK branch: release/sdk-5.0",
+    description="A package to work with Infoworks via SDK. This library is compatible with Infoworks v6.2.0 onwards. Code can be found in https://github.com/Infoworks/InfoworksPythonSDK branch: release/sdk-5.1",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/Infoworks/InfoworksPythonSDK",

--- a/test_cases/config_jsons/workflow_configurations.json
+++ b/test_cases/config_jsons/workflow_configurations.json
@@ -11,9 +11,12 @@
                 "exported_at": "2023-01-25T04:27:38.407Z",
                 "exported_by": "Infoworks Admin"
             },
-            "workflow": {
-                "description": "",
-                "workflow_graph": {
+            "workflow_export": {
+                "workflow_model": {
+                    "description": ""
+                },
+                "workflow_version_model": {
+                    "workflow_graph": {
                     "tasks": [
                         {
                             "is_group": false,
@@ -52,6 +55,7 @@
                             "category": "LINK"
                         }
                     ]
+                }
                 }
             }
         }

--- a/test_cases/workflow_test_cases.py
+++ b/test_cases/workflow_test_cases.py
@@ -2,7 +2,6 @@ import datetime
 import json
 import logging
 import os
-import sys
 import time
 import pytest
 import sys
@@ -82,6 +81,107 @@ class TestWorkflowFlow():
             print(str(e))
             assert False
 
+    @pytest.mark.dependency(depends=["TestWorkflowFlow::test_create_workflow"])
+    def test_create_workflow_version(self):
+        try:
+            workflow_id = pytest.workflows["workflow_api_test_1"]
+            workflow_version_config = {
+                "description": "Test version",
+                "is_active": True,
+                "workflow_graph": {
+                    "tasks": [
+                        {
+                            "is_group": False,
+                            "task_type": "bash_command_run",
+                            "task_id": "BS_3UWO",
+                            "location": "-175 -155",
+                            "title": "Bash Script",
+                            "description": "",
+                            "task_properties": {
+                                "is_script_uploaded": False,
+                                "bash_command": "echo \"Hello Workflow\""
+                            },
+                            "run_properties": {
+                                "trigger_rule": "all_success",
+                                "num_retries": 0
+                            }
+                        }
+                    ],
+                    "edges": []
+                }
+            }
+            response = iwx_client.create_workflow_version(
+                domain_id=pytest.domain_id,
+                workflow_id=workflow_id,
+                workflow_version_config=workflow_version_config
+            )
+            assert response["result"]["status"].upper() == "SUCCESS"
+            pytest.workflow_version_id = response["result"]["workflow_version_id"]
+            workflow_id = pytest.workflows["workflow_api_test_1"]
+            workflow_version_config['is_active'] = False
+            workflow_version_config['description'] = 'version for delete test'
+            response = iwx_client.create_workflow_version(
+                domain_id=pytest.domain_id,
+                workflow_id=workflow_id,
+                workflow_version_config=workflow_version_config
+            )
+            assert response["result"]["status"].upper() == "SUCCESS"
+            pytest.workflow_version_id_for_delete = response["result"]["workflow_version_id"]
+            assert response["result"]["status"].upper() == "SUCCESS"
+        except WorkflowError as e:
+            print(str(e))
+            assert False
+
+    @pytest.mark.dependency(depends=["TestWorkflowFlow::test_create_workflow_version"])
+    def test_update_workflow_version(self):
+        try:
+            workflow_id = pytest.workflows["workflow_api_test_1"]
+            workflow_version_id = pytest.workflow_version_id
+            workflow_version_config = {
+                "description": "Updated version",
+                "is_active": True
+            }
+            response = iwx_client.update_workflow_version(
+                workflow_version_id=workflow_version_id,
+                workflow_id=workflow_id,
+                domain_id=pytest.domain_id,
+                workflow_version_config=workflow_version_config
+            )
+            print(response)
+            assert response["result"]["status"].upper() == "SUCCESS"
+        except WorkflowError as e:
+            print(str(e))
+            assert False
+
+    @pytest.mark.dependency(depends=["TestWorkflowFlow::test_create_workflow_version"])
+    def test_get_list_of_workflow_versions(self):
+        try:
+            workflow_id = pytest.workflows["workflow_api_test_1"]
+            workflow_versions_in_workflow_get_response = iwx_client.get_list_of_workflow_versions(
+                domain_id=pytest.domain_id,
+                workflow_id=workflow_id
+            )
+            workflow_versions_all_get_response = iwx_client.get_list_of_workflow_versions()
+            assert workflow_versions_in_workflow_get_response["result"]["status"].upper() == "SUCCESS" and \
+                   workflow_versions_all_get_response["result"]["status"].upper() == "SUCCESS"
+        except WorkflowError as e:
+            print(str(e))
+            assert False
+
+    @pytest.mark.dependency(depends=["TestWorkflowFlow::test_create_workflow_version"])
+    def test_delete_workflow_version(self):
+        try:
+            workflow_id = pytest.workflows["workflow_api_test_1"]
+            workflow_version_id = pytest.workflow_version_id_for_delete
+            response = iwx_client.delete_workflow_version(
+                workflow_version_id=workflow_version_id,
+                workflow_id=workflow_id,
+                domain_id=pytest.domain_id
+            )
+            assert response["result"]["status"].upper() == "SUCCESS"
+        except WorkflowError as e:
+            print(str(e))
+            assert False
 
     @pytest.mark.dependency(depends=["TestWorkflowFlow::test_update_workflow_schedule_user"])
     def test_enable_workflow_schedule(self):
@@ -224,8 +324,8 @@ class TestWorkflowFlow():
     def test_export_workflow_configuration_json(self):
         try:
             workflow_get_json_response = iwx_client.get_workflow_configuration_json_export(
-                pytest.workflows["workflow_api_test_1"],
-                pytest.domain_id)
+                workflow_id=pytest.workflows["workflow_api_test_1"],
+                domain_id=pytest.domain_id)
             print("workflow_get_json_response", workflow_get_json_response)
             if workflow_get_json_response["result"]["status"].upper() == "SUCCESS":
                 with open(f"{cwd}/config_jsons/workflow_export_configurations.json", "w") as f:
@@ -250,10 +350,14 @@ class TestWorkflowFlow():
             assert False
 
 
-    @pytest.mark.dependency(depends=["TestWorkflowFlow::test_export_workflow_configuration_json"])
+    @pytest.mark.dependency(depends=["TestWorkflowFlow::test_create_workflow_version"])
     def test_trigger_workflow(self):
         try:
-            workflow_get_response = iwx_client.trigger_workflow(pytest.workflows["workflow_api_test_1"], pytest.domain_id)
+            workflow_get_response = iwx_client.trigger_workflow_version(
+                workflow_version_id=pytest.workflow_version_id,
+                workflow_id=pytest.workflows["workflow_api_test_1"],
+                domain_id=pytest.domain_id)
+            print(workflow_get_response)
             pytest.workflow_run_id = workflow_get_response["result"]["response"].get('result', {}).get('id', None)
             if pytest.workflow_run_id is None:
                 assert False
@@ -316,16 +420,18 @@ class TestWorkflowFlow():
     def test_restart_or_cancel_multiple_workflows(self):
         # Restart Multiple Workflows (This operation is only for operations_analyst user)
         try:
-            workflow_get_response = iwx_client.trigger_workflow(pytest.workflows[next(iter(pytest.workflows))],
-                                                                pytest.domain_id)
+            workflow_get_response = iwx_client.trigger_workflow_version(
+                workflow_id=pytest.workflows['workflow_api_test_1'],
+                workflow_version_id=pytest.workflow_version_id,
+                domain_id=pytest.domain_id)
             pytest.workflow_run_id = workflow_get_response["result"]["response"].get('result', {}).get('id', None)
             workflow_cancel_response = iwx_client.cancel_multiple_workflow(
                 {"ids": [
-                    {"workflow_id": pytest.workflows[next(iter(pytest.workflows))], "run_id": pytest.workflow_run_id}]})
+                    {"workflow_id": pytest.workflows['workflow_api_test_1'], "run_id": pytest.workflow_run_id}]})
             time.sleep(10)
             workflow_restart_response = iwx_client.restart_or_cancel_multiple_workflows(
                 workflow_list_body={"ids": [
-                    {"workflow_id": pytest.workflows[next(iter(pytest.workflows))], "run_id": pytest.workflow_run_id}]})
+                    {"workflow_id": pytest.workflows['workflow_api_test_1'], "run_id": pytest.workflow_run_id}]})
             assert workflow_cancel_response["result"]["status"].upper() == "SUCCESS" and \
                    workflow_restart_response["result"]["status"].upper() == "SUCCESS"
         except WorkflowError as e:
@@ -337,15 +443,19 @@ class TestWorkflowFlow():
     def test_pause_or_resume_multiple_workflows(self):
         try:
             workflow_pause_response = iwx_client.pause_or_resume_multiple_workflows(workflow_list_body={
-                "workflow_ids": [pytest.workflows[next(iter(pytest.workflows))]]
+                "workflows": [{
+                     'workflow_id': pytest.workflows['workflow_api_test_1'],
+                     'workflow_version_id': pytest.workflow_version_id
+                 }]
             })
             print(workflow_pause_response)
             time.sleep(30)
             workflow_resume_response = iwx_client.pause_or_resume_multiple_workflows(action_type="resume",
                                                                                      workflow_list_body={
-                                                                                         "workflow_ids": [pytest.workflows[
-                                                                                                              next(iter(
-                                                                                                                  pytest.workflows))]]
+                                                                                         "workflows": [{
+                                                                                             'workflow_id': pytest.workflows['workflow_api_test_1'],
+                                                                                             'workflow_version_id': pytest.workflow_version_id
+                                                                                         }]
                                                                                      })
             print(workflow_resume_response)
             assert workflow_pause_response["result"]["status"].upper() == "SUCCESS" and workflow_resume_response["result"][


### PR DESCRIPTION
Changes
1. Change in request body of  `update_workflow`, `pause_or_resume_multiple_workflows `, `update_workflow_configuration_json_import`, `update_workflow`.
2. New Methods `get_list_of_workflow_versions `,  `create_workflow_version `, `update_workflow_version `, `delete_workflow_version `.
3. Method name changed from `trigger_workflow` to `trigger_workflow_version ` and will need workflow_version_id as well along with domain and workflow ids.
4. `get_workflow_configuration_json_export ` will need workflow_version_id if user want to export particular version if not provided active version will be exported and exported json structure for workflow config is changed. detailed response can be found in test case dataset [workflow_config_dataset](https://github.com/Infoworks/infoworks-python-sdk/blob/release/sdk-5.1/test_cases/config_jsons/workflow_configurations.json)
5. `update_workflow_configuration_json_import` this will create new workflow version if flag `is_workflow_version_active` passed as true in import configs will set imported version to active.